### PR TITLE
NFT gated spaces - only NFT holders can publish posts 

### DIFF
--- a/contracts/Accounts.sol
+++ b/contracts/Accounts.sol
@@ -115,6 +115,8 @@ contract Accounts is OwnableUpgradeable {
     function connect_metamask_address(uint64 account_id) public {
         Account storage account = accounts[account_id];
         require(account._address != msg.sender, "You need to send this message via Metamask");
+        
+        // TODO: Allow connected_addresses
         account.connected_addresses[0] = msg.sender;
     }
 

--- a/contracts/Accounts.sol
+++ b/contracts/Accounts.sol
@@ -113,7 +113,8 @@ contract Accounts is OwnableUpgradeable {
 
     // This method gets called by metamask and adds the address to accounts connected_addresses
     function connect_metamask_address(uint64 account_id) public {
-        Account memory account = accounts[account_id];
+        Account storage account = accounts[account_id];
+        require(account._address != msg.sender, "You need to send this message via Metamask");
         account.connected_addresses[0] = msg.sender;
     }
 

--- a/contracts/Accounts.sol
+++ b/contracts/Accounts.sol
@@ -38,8 +38,8 @@ contract Accounts is OwnableUpgradeable {
     function _sign_up(address _address, string calldata username) internal {
         uint64 id = ++signup_counter;
         string memory username_lower = _string_to_lower(username);
-
-        accounts[id] = Account(username, "", "", _address);
+        address[] memory arr;
+        accounts[id] = Account(username, "", "", _address, arr);
         id_by_address[_address] = id;
         id_by_username[username_lower] = id;
 
@@ -110,6 +110,18 @@ contract Accounts is OwnableUpgradeable {
         }
         return string(bytes_output);
     }
+
+    // This method gets called by metamask and adds the address to accounts connected_addresses
+    function connect_metamask_address(uint64 account_id) public {
+        Account memory account = accounts[account_id];
+        account.connected_addresses[0] = msg.sender;
+    }
+
+    function get_connected_addresses(uint64 account_id) external view returns (address[] memory) {
+        Account memory account = accounts[account_id];
+        require(account._address == msg.sender, "You dont have permission to do this!");
+        return account.connected_addresses;
+    }
 }
 
 struct Account {
@@ -117,4 +129,5 @@ struct Account {
     string public_key;
     string profile_picture;
     address _address;
+    address[] connected_addresses;
 }

--- a/contracts/Posts.sol
+++ b/contracts/Posts.sol
@@ -73,6 +73,10 @@ contract Posts is OwnableUpgradeable {
         uint256 length = bytes(message).length;
         require(length <= 280, "Cannot submit post: message too long");
 
+
+        bool isAllowedToPost = contracts.spaces().is_allowed(space, user_id);
+        require(!isAllowedToPost, "Cannot submit post: you don't have the rights to post in this space!");
+
         bool is_blacklisted = contracts.spaces().is_blacklisted(space, user_id);
         require(!is_blacklisted, "Cannot submit post: you are on this space's blacklist");
 

--- a/contracts/Posts.sol
+++ b/contracts/Posts.sol
@@ -75,7 +75,7 @@ contract Posts is OwnableUpgradeable {
 
 
         bool isAllowedToPost = contracts.spaces().is_allowed(space, user_id);
-        require(!isAllowedToPost, "Cannot submit post: you don't have the rights to post in this space!");
+        require(isAllowedToPost, "Cannot submit post: you don't have the rights to post in this space!");
 
         bool is_blacklisted = contracts.spaces().is_blacklisted(space, user_id);
         require(!is_blacklisted, "Cannot submit post: you are on this space's blacklist");

--- a/contracts/Posts.sol
+++ b/contracts/Posts.sol
@@ -73,8 +73,7 @@ contract Posts is OwnableUpgradeable {
         uint256 length = bytes(message).length;
         require(length <= 280, "Cannot submit post: message too long");
 
-
-        bool isAllowedToPost = contracts.spaces().is_allowed(space, user_id);
+        bool isAllowedToPost = contracts.spaces().is_allowed(space, user_id, msg.sender);
         require(isAllowedToPost, "Cannot submit post: you don't have the rights to post in this space!");
 
         bool is_blacklisted = contracts.spaces().is_blacklisted(space, user_id);

--- a/contracts/Spaces.sol
+++ b/contracts/Spaces.sol
@@ -77,8 +77,15 @@ contract Spaces is OwnableUpgradeable {
     }
 
     function is_allowed(uint64 space, uint64 account) public view returns(bool) {
-    
+        
+
         Space memory _space = spaces[space];
+
+        // Public space, allow access
+        if(_space.nft_address == 0x0000000000000000000000000000000000000000) {
+            return true;
+        }
+
         ERC721 nft = ERC721(_space.nft_address);
 
         // TODO: Get account address  - msg.sender maybe has no nfts, but a linked account 

--- a/contracts/Spaces.sol
+++ b/contracts/Spaces.sol
@@ -77,8 +77,6 @@ contract Spaces is OwnableUpgradeable {
     }
 
     function is_allowed(uint64 space, uint64 account) public view returns(bool) {
-        
-
         Space memory _space = spaces[space];
 
         // Public space, allow access
@@ -88,8 +86,13 @@ contract Spaces is OwnableUpgradeable {
 
         ERC721 nft = ERC721(_space.nft_address);
 
-        // TODO: Get account address  - msg.sender maybe has no nfts, but a linked account 
-        uint256 ownerTokenCount = nft.balanceOf(msg.sender);
+        // Get account address  - msg.sender maybe has no nfts, but a linked account 
+        address[] memory addresses = contracts.accounts().get_connected_addresses(account);
+
+        uint256 ownerTokenCount = 0;
+        for (uint256 i; i < addresses.length; i++) {
+            ownerTokenCount += nft.balanceOf(addresses[i]);
+        }
 
         if (ownerTokenCount > 0) {
             return true;

--- a/contracts/Spaces.sol
+++ b/contracts/Spaces.sol
@@ -76,7 +76,7 @@ contract Spaces is OwnableUpgradeable {
         return blacklist[space_account_id];
     }
 
-    function is_allowed(uint64 space, uint64 account) public view returns(bool) {
+    function is_allowed(uint64 space, uint64 account, address sender) public view returns(bool) {
         Space memory _space = spaces[space];
 
         // Public space, allow access
@@ -93,6 +93,10 @@ contract Spaces is OwnableUpgradeable {
         for (uint256 i; i < addresses.length; i++) {
             ownerTokenCount += nft.balanceOf(addresses[i]);
         }
+
+        // If user has the NFT on the Decensored account address (this is not recommended!)
+        ownerTokenCount += nft.balanceOf(sender);
+
 
         if (ownerTokenCount > 0) {
             return true;

--- a/contracts/Spaces.sol
+++ b/contracts/Spaces.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "hardhat/console.sol";
 import "./Contracts.sol";
@@ -26,18 +27,18 @@ contract Spaces is OwnableUpgradeable {
         return id_counter;
     }
 
-    function create(string calldata name, string calldata description) public {
+    function create(string calldata name, string calldata description, address nft_address) public {
         contracts.rate_control().perform_action(msg.sender);
         _require_legal_space_name(name);
         require(id_by_name[name] == 0, "cannot create space: a space with this name already exists");
         uint64 owner = contracts.accounts().id_by_address(msg.sender);
-        _create(name, owner, description);
+        _create(name, owner, description, nft_address);
     }
 
-    function _create(string calldata name, uint64 owner, string calldata description) internal {
+    function _create(string calldata name, uint64 owner, string calldata description, address nft_address) internal {
         uint64 id = ++id_counter;
         _require_legal_description(description);
-        spaces[id] = Space(id, owner, name, description);
+        spaces[id] = Space(id, owner, name, description, nft_address);
         id_by_name[name] = id;
     }
 
@@ -73,6 +74,21 @@ contract Spaces is OwnableUpgradeable {
     function is_blacklisted(uint64 space, uint64 account) public view returns(bool) {
         uint128 space_account_id = _encode_two_uint64_as_uint128(space, account);
         return blacklist[space_account_id];
+    }
+
+    function is_allowed(uint64 space, uint64 account) public view returns(bool) {
+    
+        Space memory _space = spaces[space];
+        ERC721 nft = ERC721(_space.nft_address);
+
+        // TODO: Get account address  - msg.sender maybe has no nfts, but a linked account 
+        uint256 ownerTokenCount = nft.balanceOf(msg.sender);
+
+        if (ownerTokenCount > 0) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     function _encode_two_uint64_as_uint128(uint64 a, uint64 b) public pure returns(uint128) {
@@ -116,4 +132,5 @@ struct Space {
     uint64 owner;
     string name;
     string description;
+    address nft_address;
 }

--- a/contracts/TestNFT.sol
+++ b/contracts/TestNFT.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract TestNFT is ERC721, Ownable {
+    string public baseURI;
+
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        string memory _initBaseURI
+    ) ERC721(_name, _symbol) {
+        baseURI = _initBaseURI;
+    }
+
+    function _baseURI() internal view virtual override returns (string memory) {
+        return baseURI;
+    }
+
+    function safeMint(address to, uint256 tokenId) public onlyOwner {
+        _safeMint(to, tokenId);
+    }
+}

--- a/docs/handeMetamask.md
+++ b/docs/handeMetamask.md
@@ -1,0 +1,16 @@
+# How to handle multiple Metamask accounts
+
+First, there are different usages of the same term "account".
+
+- Metamask account, a browser wallet which has a secret private key and a public key, the address, for each account.
+- Decensored account, is created within the decensored smart contract. The private key is stored in the local storage of the browser. 
+
+Because the browser storage is not the securest place in the internet, we allow to connect multiple metamask accounts to the Decensored account - so assets like tokens and NFTs are stored in the secure environment and are still usable.
+
+To connect a metamask account, you need to go through the following steps:
+
+1. add the metamask account address to the Decensored account via the `addExternAddress` function.
+
+2. Call the `validateExternAddress` function via your metamask account to verify that youre the owner of that metamask account.
+
+That's it! The Decensored account is now connected to the metamask account.

--- a/docs/handeMetamask.md
+++ b/docs/handeMetamask.md
@@ -14,3 +14,5 @@ To connect a metamask account, you need to go through the following steps:
 2. Call the `validateExternAddress` function via your metamask account to verify that youre the owner of that metamask account.
 
 That's it! The Decensored account is now connected to the metamask account.
+
+![handleMetamask](./handleMetamask.drawio.svg "handleMetamask")

--- a/docs/handleMetamask.drawio.svg
+++ b/docs/handleMetamask.drawio.svg
@@ -1,0 +1,337 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1641px" height="1171px" viewBox="-0.5 -0.5 1641 1171" content="&lt;mxfile&gt;&lt;diagram id=&quot;yDa2iifg-dl7ehnwTh-9&quot; name=&quot;Seite-1&quot;&gt;7Vtdc6o4GP41zpxe1AlB0XNZbbu7F53Z2Z7Zc3kmkoiZAmEDFtxfvwkEMSR+VdSePdYL8Q35ep73M9CeO42K3zhKFi8Mk7AHAS567mMPQgcAR3xJyaqSDMfDShBwitVNjeCV/kvqnkq6pJik2o0ZY2FGE13oszgmfqbJEOcs12+bs1CfNUEBMQSvPgpN6XeKs0UlHQDx17T8TmiwUHN7TVOE6vuVIF0gzPINkfvUc6ecsay6ioopCSV+NTRVv+ctreu1cRJnh3Rw1TreUbhU+/ub8IyK7QrplMUZojHharHZqgYhzWkUolj8mgQcYSqmm7KQcdEas1I8p2FYizCZo2UoFjRJM87eSC3vQRd7M2/oiRbOljEmcllA3qfGf7aOotYsFkqKrRt31nAKVSQsIhlfiVuKmq+qx0pXrrxh1PHqexYbZDrOSEmR0qNgPXaDs7hQUNthhwbqJsIlUrWGORKTWlckQBilizVaKKRBLK59sXlBljtZZFHY9ErkkFERSHvsR8x/WyZ9v6Y27c+kTRD+ncbl8BOubA7Y+PLKP70FVk0AjP35XG9yqyZ/ID+iKRJzfiNFBeZUTkb8JU/pO/mLpM20HRDsAJ3hoYVhAG0Mr6WnMOwaDP8p/Qqsvd9VmEaxv5BETuZCplh2Ruq3jeR6upDMD7Y7uJMWr2V30GTFsZACvdMpGRiULLJMBo0HOQR8zvO8jznK+5R9Bo42zfB6fDmuTphnmtHatLombGgQNlUxHYIXkqEXlL6JywffF7EjMzhrIopEPl/QjLwmyJetuQBfJ6YLqHSkILBBNTSh8jpwN44ZxxuEtsfuDnY9aEdS90ANWYfXk/Y9skRSr0wSMH3X9u39s5RZ1cSv7EYYPeDB7EvpgoAMRhC0ru/kDwkSmCH/LSj16b7VXe5W9dAum77SVu/nKKLhquomloKipGx03TIokjhkhnQ9mHk/i5F/TAdhH5zKLA7EJN/eT4zL0tJC6rWHwifd16TJtTvjpGigFFeB+q6yuwTF+zCXOZ+PfYTMYQSJFKOMPBXCb8YPGHOSpl8ovqvHF9pQTaFPK8Ql2bW0pe97LF93E4dlHmCnSThDPfOAFouwZR5dOALPsIeczNx+QLLaH9S43l0RKIXM6ILAQKuHbIeQSqFmvFYmBValuqAYeqPxsbChNKnK0DktJHqdqBhsZbeOLb21JVJr4SlY2pxuCxSCRdGsfqqK0Ii28p7dUUcMKVyXT7R8IENcqPOGupsocRKiTBQV2uin7Hh8CzP/mzCDMNYjDKq+P12Y2Z14jVqllDXfPJc3/XodD+CZHmB8IQ/gmOVj91t2zC2PzS077qX2bJ5TPRJR1qaMC02G4DVCXBZj8pyQI98swY4tNfYc6Tjt04OxqfIDYFH5r6CLDMKsR8+gARatd1yLDgwvpQPmSZbwl0LwrQkN8SxNNhylDEU9eQBfH1A0HtjFA/nZFIE58nU3rgKVihVlDJqW42nhpRVKjg4WHwq27VkilCQ0DvZHjgqTy1Uou2NHy45sebi1ZO+iYrdZ0eFx/eBc6mfOhzpRTbOY2aOl3VqK2sovQ10bfop/zFY/VGrZHRe/DJ5dmgIoHCgmguB+PbVCWz6O2UZNI1nG6mEywTWjJJX0Cqe2JQbuZdqxLqc3nLDqlGH4eMjKbvpyDn3pnm0SJdnq2Lj/wZOjPWXj/oMjaHvwDbs4rrc8g7tMCr1+U2QjhYaXKqPqMW6nRz/L6VGJ+aCBqnV9DG4LEr4T+UKNdUt7iBs0VGuXFp+1ryjbkmhcuVY7Kts8Ao1PXf3tiBkXfo61O1SM9VBx0edYlhdobnXKrU75fHhetU75WDJ6I+8c5J2jSLwxdQ6mVDG2v7q+TtX/+YpEzxb5z1ckmk+dzlAkWh6zjCw14pYnUt0/ZjHfMNAetW19Q+WPR1X0mE2tl1eq2HIR7dqpXA5oJZau5ZXBzl5eET+bf6co2zb+L8V9+g8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 0 23 L 0 0 L 1640 0 L 1640 23" fill="rgb(255, 255, 255)" stroke="#d6b656" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 0 23 L 0 1170 L 1640 1170 L 1640 23" fill="rgb(255, 255, 255)" stroke="#d6b656" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 0 23 L 1640 23" fill="none" stroke="#d6b656" stroke-miterlimit="10" pointer-events="all"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" text-anchor="middle" font-size="12px">
+            <text x="819.5" y="16">
+                Vertical Container
+            </text>
+        </g>
+        <path d="M 60 40 L 1080 40 L 1080 1060 L 60 1060 Z" fill="rgb(255, 255, 255)" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="1015" cy="55" rx="10" ry="10" fill="none" stroke="#666666" pointer-events="all"/>
+        <ellipse cx="1040" cy="55" rx="10" ry="10" fill="none" stroke="#666666" pointer-events="all"/>
+        <ellipse cx="1065" cy="55" rx="10" ry="10" fill="none" stroke="#008cff" pointer-events="all"/>
+        <path d="M 60 80 L 90 80 L 90 55 C 90 52.24 92.24 50 95 50 L 230 50 C 232.76 50 235 52.24 235 55 L 235 80 L 1080 80" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 60 150 L 1080 150" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 160 100 C 160 97.24 162.24 95 165 95 L 1065 95 C 1067.76 95 1070 97.24 1070 100 L 1070 125 C 1070 127.76 1067.76 130 1065 130 L 165 130 C 162.24 130 160 127.76 160 125 Z" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <g fill="#666666" font-family="Arial,Helvetica" font-size="17px"/>
+        <g fill="#666666" font-family="Arial,Helvetica" font-size="17px"/>
+        <path d="M 97 57 L 108 57 L 112 61 L 112 75 L 97 75 Z" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 108 57 L 108 61 L 112 62" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 167 104 L 178 104 L 182 108 L 182 122 L 167 122 Z" fill="none" stroke="#c4c4c4" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 178 104 L 178 108 L 182 109" fill="none" stroke="#c4c4c4" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 72 114 L 82 104 L 82 110 L 92 110 L 92 118 L 82 118 L 82 124 Z" fill="#c4c4c4" stroke="#c4c4c4" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 122 114 L 112 104 L 112 110 L 102 110 L 102 118 L 112 118 L 112 124 Z" fill="#c4c4c4" stroke="#c4c4c4" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 147.6 117.3 C 145.9 120.13 142.22 121.06 139.38 119.36 C 136.54 117.67 135.61 114 137.29 111.15 C 138.98 108.31 142.65 107.36 145.5 109.04 L 143.9 110.5 L 151.8 112.3 L 150 104.8 L 148.3 106.4 C 145.11 104.03 140.8 103.82 137.39 105.87 C 133.99 107.92 132.16 111.83 132.77 115.76 C 133.37 119.69 136.3 122.86 140.16 123.79 C 144.03 124.72 148.07 123.22 150.4 120 Z" fill="#c4c4c4" stroke="#c4c4c4" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 65px; margin-left: 122px;">
+                        <div data-drawio-colors="color: #666666; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 17px; font-family: Helvetica; color: rgb(102, 102, 102); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                Page 1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="122" y="70" fill="#666666" font-family="Helvetica" font-size="17px">
+                    Page 1
+                </text>
+            </switch>
+        </g>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 113px; margin-left: 192px;">
+                        <div data-drawio-colors="color: #666666; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 17px; font-family: Helvetica; color: rgb(102, 102, 102); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                https://www.draw.io
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="192" y="118" fill="#666666" font-family="Helvetica" font-size="17px">
+                    https://www.draw.io
+                </text>
+            </switch>
+        </g>
+        <rect x="70" y="240" width="255" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 253px; height: 1px; padding-top: 270px; margin-left: 71px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Connect MetaMask Account
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="198" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Connect MetaMask Account
+                </text>
+            </switch>
+        </g>
+        <path d="M 500 193 L 500 170 L 750 170 L 750 193" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 500 193 L 500 810 L 750 810 L 750 193" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 500 193 L 750 193" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="624.5" y="186">
+                MetaMask
+            </text>
+        </g>
+        <rect x="515" y="690" width="220" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 218px; height: 1px; padding-top: 720px; margin-left: 516px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <div style="color: rgb(212 , 212 , 212) ; background-color: rgb(30 , 30 , 30) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; line-height: 18px">
+                                    <span style="color: #dcdcaa">
+                                        validateExternAddress(id)
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="625" y="724" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    validateExternAddress(id)
+                </text>
+            </switch>
+        </g>
+        <rect x="500" y="240" width="220" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 218px; height: 1px; padding-top: 270px; margin-left: 501px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                web3.getMetaMaskAddress()
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="610" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    web3.getMetaMaskAddress()
+                </text>
+            </switch>
+        </g>
+        <rect x="700" y="320" width="110" height="110" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 375px; margin-left: 701px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                MetMask Account
+                                <br/>
+                                Address: 0x5678
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="755" y="379" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    MetMask Account...
+                </text>
+            </switch>
+        </g>
+        <path d="M 325 270 L 493.63 270" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 498.88 270 L 491.88 273.5 L 493.63 270 L 491.88 266.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <rect x="820" y="240" width="220" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 218px; height: 1px; padding-top: 270px; margin-left: 821px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <div style="color: rgb(212 , 212 , 212) ; background-color: rgb(30 , 30 , 30) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; line-height: 18px">
+                                    <span style="color: #dcdcaa">
+                                        addExternAddress(address)
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="930" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    addExternAddress(address)
+                </text>
+            </switch>
+        </g>
+        <path d="M 720 270 L 813.63 270" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 818.88 270 L 811.88 273.5 L 813.63 270 L 811.88 266.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1040 270 L 1173.63 270" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1178.88 270 L 1171.88 273.5 L 1173.63 270 L 1171.88 266.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1120 193 L 1120 170 L 1520 170 L 1520 193" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1120 193 L 1120 1070 L 1520 1070 L 1520 193" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1120 193 L 1520 193" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="1319.5" y="186">
+                Decensored Smart Contract
+            </text>
+        </g>
+        <path d="M 1305.88 300 L 1306.28 313.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1306.44 318.88 L 1302.73 311.99 L 1306.28 313.63 L 1309.73 311.78 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <rect x="1180" y="240" width="250" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 270px; margin-left: 1181px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                add To
+                                <font color="#d4d4d4" face="menlo, monaco, courier new, monospace">
+                                    <span style="background-color: rgb(30 , 30 , 30)">
+                                        mapping
+                                    </span>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1305" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    add To mapping
+                </text>
+            </switch>
+        </g>
+        <rect x="1190" y="320" width="240" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 440px; margin-left: 1191px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    <br/>
+                                </span>
+                                <span style="background-color: rgb(30 , 30 , 30) ; color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace">
+                                    id_by_address
+                                    <br/>
+                                </span>
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    0x1234 -&gt; 1
+                                    <br/>
+                                    <br/>
+                                    unconnected_addresses_by_id
+                                    <br/>
+                                </span>
+                                1 -&gt; [ox5678]
+                                <br/>
+                                <br/>
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    connected_addresses_by_id
+                                    <br/>
+                                </span>
+                                empty
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1310" y="444" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    id_by_address...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1310 750 L 1310 783.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1310 788.88 L 1306.5 781.88 L 1310 783.63 L 1313.5 781.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <rect x="1200" y="690" width="220" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 218px; height: 1px; padding-top: 720px; margin-left: 1201px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <div style="color: rgb(212 , 212 , 212) ; background-color: rgb(30 , 30 , 30) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; line-height: 18px">
+                                    <span style="color: rgb(240 , 240 , 240) ; font-family: &quot;helvetica&quot; ; background-color: rgb(42 , 42 , 42)">
+                                        add To
+                                    </span>
+                                    <font color="#d4d4d4" face="menlo, monaco, courier new, monospace" style="background-color: rgb(42 , 42 , 42)">
+                                        <span style="background-color: rgb(30 , 30 , 30)">
+                                            mapping
+                                        </span>
+                                    </font>
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1310" y="724" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    add To mapping
+                </text>
+            </switch>
+        </g>
+        <rect x="1190" y="790" width="240" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 910px; margin-left: 1191px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <span style="background-color: rgb(30 , 30 , 30) ; color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace">
+                                    id_by_address
+                                    <br/>
+                                </span>
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    0x1234 -&gt; 1
+                                    <br/>
+                                    <br/>
+                                </span>
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    unconnected_addresses_by_id
+                                    <br/>
+                                </span>
+                                <span style="color: rgb(212 , 212 , 212) ; font-family: &quot;menlo&quot; , &quot;monaco&quot; , &quot;courier new&quot; , monospace ; background-color: rgb(30 , 30 , 30)">
+                                    empty
+                                    <br/>
+                                    <br/>
+                                    connected_addresses_by_id
+                                    <br/>
+                                </span>
+                                1 -&gt; [ox5678]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1310" y="914" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    id_by_address...
+                </text>
+            </switch>
+        </g>
+        <path d="M 735 720 L 1193.63 720" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1198.88 720 L 1191.88 723.5 L 1193.63 720 L 1191.88 716.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <rect x="1040" y="320" width="110" height="110" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 375px; margin-left: 1041px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Decensored Account
+                                <br/>
+                                ID: 1
+                                <br/>
+                                Address: 0x1234
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1095" y="379" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Decensored Account...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -76,6 +76,12 @@ module.exports = {
       accounts: [process.env.PRIVATEKEY],
       timeout: 60000,
     },
+    strangled: {
+      url: "https://evm.iotabot.strangled.net/",
+      chainId: 1076,
+      accounts: [process.env.PRIVATEKEY],
+      timeout: 120000
+    },
   },
   solidity: {
     version: "0.8.4",

--- a/test/test_accounts.js
+++ b/test/test_accounts.js
@@ -83,16 +83,15 @@ describe("Accounts", function () {
     });
 
     it("Should add metamask address to connected addresses array", async function () {
-        // TODO
-        [addr0, addr1] = await ethers.getSigners();
-        let account_id = (await accounts.id_by_address(addr0.address)).toNumber()
+        [decensored, metamask] = await ethers.getSigners();
+        let account_id = (await accounts.id_by_address(decensored.address)).toNumber()
         
         // Check if unconnected_addresses array is empty
         let my_unconnected_addresses = await accounts.get_unconnected_addresses(account_id)
         expect(my_unconnected_addresses.length).to.equal(0);
         
         // Adds external address
-        await accounts.addExternAddress(addr1.address)
+        await accounts.addExternAddress(metamask.address)
 
         // Check if unconnected_addresses array has one entry
         my_unconnected_addresses = await accounts.get_unconnected_addresses(account_id)
@@ -103,8 +102,8 @@ describe("Accounts", function () {
         const contract = await Contract.attach(accounts.address);
 
         // validate metamask address
-        // use another account (addr1) to sign the tx
-        await contract.connect(addr1).validateExternAddress(account_id)
+        // use another account (metamask) to sign the tx
+        await contract.connect(metamask).validateExternAddress(account_id)
         
         // Check if unconnected_addresses array is empty again
         my_unconnected_addresses = await accounts.get_unconnected_addresses(account_id)

--- a/test/test_gated_spaces.js
+++ b/test/test_gated_spaces.js
@@ -1,0 +1,108 @@
+const { expect, assert } = require("chai");
+const { ethers } = require("hardhat");
+const utils = require("../scripts/utils.js");
+const { sha256 } = require("ethers/lib/utils");
+
+describe("NFT Gated Spaces", function () {
+  let contracts;
+  let accounts;
+  let rate_control;
+  let spaces;
+  let posts;
+
+  let space1_name = "helloworld";
+  let space2_name = "helloworld2";
+
+  let space1_id;
+  let space2_id;
+
+  let blacklist = [3, 6, 7];
+
+  let nft_contract;
+  let nft_address;
+
+  let message = "Hola, mundo!";
+
+  let nonces = [];
+
+  it("Deploy contract", async function () {
+    contracts = await utils.deploy_proxy("Contracts");
+
+    rate_control = await utils.deploy_proxy("RateControl");
+    accounts = await utils.deploy_proxy("Accounts", [contracts.address]);
+    spaces = await utils.deploy_proxy("Spaces", [contracts.address]);
+    posts = await utils.deploy_proxy("Posts", [contracts.address]);
+    tokens = await utils.deploy_proxy("Tokens", []);
+
+    await rate_control.set_rate(await utils.own_address(), 10);
+
+    for (let i = 0; i < 1; i++) {
+      let nonce = "nonce#" + i;
+      nonces.push(nonce);
+      let hash = sha256(utils.string_to_bytes(nonce));
+      await tokens.add_token_hash(hash);
+    }
+
+    await contracts.set_rate_control(rate_control.address);
+    await contracts.set_accounts(accounts.address);
+    await contracts.set_spaces(spaces.address);
+    await contracts.set_posts(posts.address);
+    await contracts.set_tokens(tokens.address);
+
+    const Contract = await ethers.getContractFactory("TestNFT");
+    nft_contract = await Contract.deploy(
+      "My NFT",
+      "MNFT",
+      "https://robohash.org/test-1.png"
+    );
+
+    await nft_contract.deployed();
+    nft_address = nft_contract.address;
+  });
+
+  it("get_amount_of_posts() should be 0 after deployment", async function () {
+    expect(await posts.get_amount_of_posts()).to.equal(0);
+  });
+
+  it("Should not be able to submit a post before signing up", async function () {
+    utils.expect_error_message(async () => {
+      await utils.submit_post(posts, 0, message);
+    }, "Cannot submit post: you are not signed up");
+  });
+
+  it("Submit a post to space with an NFT", async function () {
+    [addr1] = await ethers.getSigners();
+
+    await accounts.sign_up("user1", nonces.pop());
+    await nft_contract.safeMint(addr1.address, 1);
+
+    await spaces.create("space1", "", nft_address);
+
+    let post_address = await contracts.posts();
+
+    const Contract = await ethers.getContractFactory("Posts");
+    const contract = await Contract.attach(post_address);
+
+    expect(await posts.get_amount_of_posts()).to.equal(0);
+    await contract.connect(addr1).submit_post(1, message, {
+      value: 0,
+    });
+    expect(await posts.get_amount_of_posts()).to.equal(1);
+  });
+
+  it("Should not be able to post a message without an NFT", async function () {
+    await utils.expect_error_message(async () => {
+      [addr1, addr2] = await ethers.getSigners();
+
+      await nft_contract.transferFrom(addr1.address, addr2.address, 1);
+      let post_address = await contracts.posts();
+
+      const Contract = await ethers.getContractFactory("Posts");
+      const contract = await Contract.attach(post_address);
+
+      await contract.connect(addr1).submit_post(1, message, {
+        value: 0,
+      });
+    }, "Cannot submit post: you don't have the rights to post in this space!");
+  });
+});

--- a/test/test_posts.js
+++ b/test/test_posts.js
@@ -51,7 +51,7 @@ describe("Posts", function () {
 
     it("Submit a post to space", async function () {
         await accounts.sign_up("micro_hash", nonces.pop());
-        await spaces.create("space1", "");
+        await spaces.create("space1", "", "0x0000000000000000000000000000000000000000");
         await utils.submit_post(posts, 1, message)
     });
 

--- a/test/test_spaces.js
+++ b/test/test_spaces.js
@@ -32,7 +32,7 @@ describe("Spaces", function () {
 
     it("Create Space", async function () {
         await rate_control.set_rate(await utils.own_address(), 10);
-        await spaces.create(space1_name, "");
+        await spaces.create(space1_name, "", "0x0000000000000000000000000000000000000000");
     });
 
     it("Set Space Description", async function () {
@@ -45,12 +45,12 @@ describe("Spaces", function () {
 
     it("Fail creating space with existing name", async function () {
         await utils.expect_error_message(async () => {
-            await spaces.create(space1_name, "");
+            await spaces.create(space1_name, "", "0x0000000000000000000000000000000000000000");
         }, "cannot create space: a space with this name already exists");
     });
 
     it("Create Space with other name", async function () {
-        await spaces.create(space2_name, "");
+        await spaces.create(space2_name, "", "0x0000000000000000000000000000000000000000");
     });
 
     it("Spaces have expected IDs", async function () {


### PR DESCRIPTION
## Description

This pull request introduces NFT gated spaces, where just NFT holders can publish new posts in a space. The space owner can add a NFT address (or multiple in the future) to make the space more restricted - public is the default. 

To enable this functionality, there is a connection to metamask account needed, where the users store their NFTs. 

The solution is to add and validate metamask addresses to the descensored user account.

## Changes

- Added `nft_address` attribute to Spaces, for public space use address: `0x0000000000000000000000000000000000000000` 
- Added `addExternAddress`function - to add the metamask address to the decensored account - but the addreess needs to be verified via the next method:
- Added `validateExternAddress` function - call it via metamask and the metamask address gets stored into the decensored account (connected_addresses array)
- Add `unconnected_addresses_by_id` mapping (`uint64 => address[]`)
- Add `connected_addresses_by_id` mapping (`uint64 => address[]`)

## Overview

![](https://raw.githubusercontent.com/huhn511/contracts/main/docs/handleMetamask.drawio.svg)